### PR TITLE
Updated to json response

### DIFF
--- a/hotel-api-model/auto/model/CancellationPolicy.cs
+++ b/hotel-api-model/auto/model/CancellationPolicy.cs
@@ -7,6 +7,6 @@ namespace com.hotelbeds.distribution.hotel_api_model.auto.model
         public decimal amount { get; set; }
         public decimal hotelAmount { get; set; }
         public string hotelCurrency { get; set; }
-        public string from { get; set; }
+        public DateTime from { get; set; }
     }
 }

--- a/hotel-api-model/auto/model/Hotel.cs
+++ b/hotel-api-model/auto/model/Hotel.cs
@@ -5,8 +5,6 @@ namespace com.hotelbeds.distribution.hotel_api_model.auto.model
 {
     public class Hotel
     {        
-        public DateTime checkIn { get; set; }
-        public DateTime checkOut { get; set; }
         public int code { get; set; }
         public string name { get; set; }
         public string categoryCode { get; set; }

--- a/hotel-api-model/auto/model/Room.cs
+++ b/hotel-api-model/auto/model/Room.cs
@@ -1,13 +1,14 @@
-﻿using System.Collections.Generic;
-using com.hotelbeds.distribution.hotel_api_model.auto.common;
+﻿using com.hotelbeds.distribution.hotel_api_model.auto.common;
+using System.Collections.Generic;
 
 namespace com.hotelbeds.distribution.hotel_api_model.auto.model
 {
     public class Room
-    {        
+    {
         public SimpleTypes.BookingStatus status;
         public string code { get; set; }
+        public string name { get; set; }
         public List<Pax> paxes { get; set; }
         public List<Rate> rates { get; set; }
-    } 
+    }
 }

--- a/hotel-api-sdk/App.config
+++ b/hotel-api-sdk/App.config
@@ -1,11 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="ApiKey" value="gfhpht2ffsfejd88g7pcnexe"/>
-    <add key="SharedSecret" value="e7Af9xbEtm"/>
-    <add key="ENVIRONTMENT" value="TEST"/>
-    <add key="TEST" value="https://api.test.hotelbeds.com/hotel-api"/>
-    <add key="LIVE" value="https://api.hotelbeds.com/hotel-api"/>
-    <add key="DEVELOPMENT" value="http://localhost:8181"/>    
+    <add key="ApiKey" value="gfhpht2ffsfejd88g7pcnexe" />
+    <add key="SharedSecret" value="e7Af9xbEtm" />
+    <add key="ENVIRONTMENT" value="TEST" />
+    <add key="TEST" value="https://api.test.hotelbeds.com/hotel-api" />
+    <add key="LIVE" value="https://api.hotelbeds.com/hotel-api" />
+    <add key="DEVELOPMENT" value="http://localhost:8181" />    
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/hotel-api-sdk/HotelApiClient.cs
+++ b/hotel-api-sdk/HotelApiClient.cs
@@ -26,8 +26,6 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
         /// <summary>
         /// Atributos
         /// </summary>
-        public int readTimeout { get; set; } = REST_TEMPLATE_READ_TIME_OUT;
-        
         private readonly string basePath;
         private readonly HotelApiVersion version;        
         private readonly string apiKey;
@@ -233,7 +231,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
                     client.BaseAddress = new Uri(path.getUrl(this.basePath, this.version));
                     client.DefaultRequestHeaders.Clear();
-                    client.Timeout = new TimeSpan(0, 0, this.readTimeout);
+                    client.Timeout = new TimeSpan(0, 0, REST_TEMPLATE_READ_TIME_OUT);
                     client.DefaultRequestHeaders.Add("Api-Key", this.apiKey);
                     client.DefaultRequestHeaders.Add("Accept-Enconding", "Gzip");
                     client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");

--- a/hotel-api-sdk/hotel-api-sdk.csproj
+++ b/hotel-api-sdk/hotel-api-sdk.csproj
@@ -85,8 +85,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/hotel-api-sdk/packages.config
+++ b/hotel-api-sdk/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
CancellationPolicy.from now is a DateTime instead of a string.
Hotel no longer has checkIn and checkOut since in the JSON response these elements does not appear.
Room now has a name, this is element is appearing in the JSON response.
Deleted the field readTimeOut from HotelClientApi. Instead now it uses the constant REST_TEMPLATE_READ_TIME_OUT
Updated Newtonsoft.Json from 6.0.4 to 7.0.1