### PR TITLE
Commented attribute JsonProperty for RateType

### DIFF
--- a/hotel-api-model/auto/model/BasicRate.cs
+++ b/hotel-api-model/auto/model/BasicRate.cs
@@ -9,7 +9,7 @@ namespace com.hotelbeds.distribution.hotel_api_model.auto.model
     {
         public string rateKey { get; set; }
         public string rateClass { get; set; }
-        [JsonProperty("rateType", Required = Required.Always)]
+        //[JsonProperty("rateType", Required = Required.Always)]
         [JsonConverter(typeof(JSonConverters.RateTypeConverter))]
         public SimpleTypes.RateType? rateType { get; set; }
         public decimal net { get; set; }


### PR DESCRIPTION
 Commented attribute JsonProperty for RateType since it was throwing an error while serializing the object since the mentioned property was null.