### PR TITLE
The consumer of the client now can set an explicit timeout

### DIFF
--- a/hotel-api-sdk-demo/App.config
+++ b/hotel-api-sdk-demo/App.config
@@ -4,6 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <appSettings>
+    <add key="TimeoutSeconds" value="5000"/>
     <add key="ApiKey" value="xxxxxxxxxxxxxxxxxxx" />
     <add key="SharedSecret" value="xxxxxxxxxxxx" />
     <add key="ENVIRONMENT" value="TEST" />

--- a/hotel-api-sdk/App.config
+++ b/hotel-api-sdk/App.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
+    <add key="TimeoutSeconds" value="5000"/>
     <add key="ApiKey" value="xxxxxxxxxxxxxxxxx" />
     <add key="SharedSecret" value="xxxxxxxxxxx" />
     <add key="ENVIRONMENT" value="TEST" />

--- a/hotel-api-sdk/HotelApiClient.cs
+++ b/hotel-api-sdk/HotelApiClient.cs
@@ -21,13 +21,9 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
         //https://developer.hotelbeds.com/docs/read/apitude_booking/
 
         /// <summary>
-        /// CONSTANTS 
-        /// </summary>
-        private const int REST_TEMPLATE_READ_TIME_OUT = 5000;
-
-        /// <summary>
         /// Atributos
         /// </summary>
+        private readonly TimeSpan timeout;
         private readonly string basePath;
         private readonly HotelApiVersion version;
         private readonly string apiKey;
@@ -36,6 +32,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
         public HotelApiClient()
         {
+            this.timeout = GetTimeoutFromConfig();
             this.apiKey = GetHotelApiKeyFromConfig();
             this.sharedSecret = GetHotelSharedSecretFromConfig();
             this.version = new HotelApiVersion(HotelApiVersion.versions.V1);
@@ -45,6 +42,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
         public HotelApiClient(HotelApiVersion version)
         {
+            this.timeout = GetTimeoutFromConfig();
             this.apiKey = GetHotelApiKeyFromConfig();
             this.sharedSecret = GetHotelSharedSecretFromConfig();
             this.version = version;
@@ -54,6 +52,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
         public HotelApiClient(string apiKey, string sharedSecret)
         {
+            this.timeout = GetTimeoutFromConfig();
             this.apiKey = apiKey;
             this.sharedSecret = sharedSecret;
             this.version = new HotelApiVersion(HotelApiVersion.versions.V1);
@@ -63,6 +62,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
         public HotelApiClient(HotelApiVersion version, string apiKey, string sharedSecret)
         {
+            this.timeout = GetTimeoutFromConfig();
             this.apiKey = apiKey;
             this.sharedSecret = sharedSecret;
             this.version = version;
@@ -87,6 +87,20 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
             catch (Exception e)
             {
                 throw e;
+            }
+        }
+
+        private TimeSpan GetTimeoutFromConfig()
+        {
+            try
+            {
+                int returnValue = int.Parse(ConfigurationManager.AppSettings.Get("TimeoutSeconds"));
+                return TimeSpan.FromSeconds(returnValue);
+            }
+            catch
+            {
+                // In case the client updated the version and did not configure the new parameter
+                return TimeSpan.FromSeconds(5000);
             }
         }
 
@@ -237,7 +251,7 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
 
                     client.BaseAddress = new Uri(path.getUrl(this.basePath, this.version));
                     client.DefaultRequestHeaders.Clear();
-                    client.Timeout = new TimeSpan(0, 0, REST_TEMPLATE_READ_TIME_OUT);
+                    client.Timeout = this.timeout;
                     client.DefaultRequestHeaders.Add("Api-Key", this.apiKey);
 
                     long ts = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds / 1000;


### PR DESCRIPTION
In the web or app config, now there is a key named **TimeoutSeconds** that is used to set an explicit timeout for the requests.

In order not to introduce breaking changes when the nuget package is updated, if this key is not setted it will default to 5000 seconds (the interval that was setted before in the client through a constant)

I hope we can see this feature added soon the package!
Thanks!
Regards