### PR TITLE
Fixed a bug where the booking response deserialization was throwing an error

### DIFF
--- a/hotel-api-sdk/HotelApiClient.cs
+++ b/hotel-api-sdk/HotelApiClient.cs
@@ -259,8 +259,8 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
                     byte[] hash = hashstring.ComputeHash(Encoding.UTF8.GetBytes(this.apiKey + this.sharedSecret + ts));
                     string signature = BitConverter.ToString(hash).Replace("-", "");
                     client.DefaultRequestHeaders.Add("X-Signature", signature.ToString());
-                    client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
-                    client.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/json");
+                    client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=utf-8");
+                    client.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/json; charset=utf-8");
 
                     // GET Method
                     if (path.getHttpMethod() == HttpMethod.Get)


### PR DESCRIPTION
This was caused because of non UTF-8 chars.
With this change this response:

```json
{
	"auditData": {
		"processTime": "4278",
		"timestamp": "2016-12-05 15:19:48.029",
		"requestHost": "181.164.93.206",
		"serverId": "sa3RKSJACHXE79K.env",
		"environment": "[int]",
		"release": "8629cf6ef0a2deed178b86daa0e13c79b5c99237",
		"internal": "0|3C9DE3DCD6DB43919D25CA03DC4040B3|MX||1|1|||||||||||R|1|7||||||wbxrv2d759hmvh4b4wu6jxyu||"
	},
	"booking": {
		"reference": "197-2985655",
		"clientReference": "SDK TEST",
		"creationDate": "2016-12-05",
		"status": "CONFIRMED",
		"modificationPolicies": {
			"cancellation": true,
			"modification": true
		},
		"creationUser": "wbxrv2d759hmvh4b4wu6jxyu",
		"holder": {
			"name": "ROSETTA",
			"surname": "PRUEBAS"
		},
		"hotel": {
			"checkIn": "2017-01-11",
			"checkOut": "2017-01-18",
			"code": 18968,
			"name": "Elysees Union",
			"categoryCode": "3EST",
			"categoryName": "3 STARS",
			"destinationCode": "PAR",
			"destinationName": "Paris",
			"zoneCode": 14,
			"zoneName": "Arr8/16:Etoile-C.Elys�es/Trocadero",
			"latitude": "48.868387",
			"longitude": "2.291788",
			"rooms": [{
				"status": "CONFIRMED",
				"id": 1,
				"code": "QUA.ST",
				"name": "QUADRUPLE STANDARD",
				"paxes": [{
					"roomId": 1,
					"type": "AD",
					"name": "NombrePasajero1",
					"surname": "ApellidoPasajero1"
				},
				{
					"roomId": 1,
					"type": "AD",
					"name": "NombrePasajero2",
					"surname": "ApellidoPasajero2"
				},
				{
					"roomId": 1,
					"type": "CH",
					"age": 12,
					"name": "NombrePasajero3",
					"surname": "ApellidoPasajero3"
				},
				{
					"roomId": 1,
					"type": "CH",
					"age": 13,
					"name": "NombrePasajero4",
					"surname": "ApellidoPasajero4"
				}],
				"rates": [{
					"rateKey": "20170111|20170118|W|197|18968|QUA.ST|FIT NET APT2|RO||1~2~2|30~30~12~13|N@0",
					"rateClass": "NOR",
					"net": "1142.58",
					"rateComments": "1x QUADRUPLE Estimated total amount of taxes & fees for this booking: 46.20 Euro   payable on arrival  ",
					"paymentType": "AT_WEB",
					"packaging": false,
					"boardCode": "RO",
					"boardName": "ROOM ONLY",
					"cancellationPolicies": [{
						"amount": "1142.58",
						"from": "2017-01-08T23:59:00+01:00"
					},
					{
						"amount": "342.77",
						"from": "2016-12-27T23:59:00+01:00"
					},
					{
						"amount": "91.41",
						"from": "2016-12-04T23:59:00+01:00"
					}],
					"rateBreakDown": {
						"rateDiscounts": [{
							"code": "SDD",
							"name": "SPECIAL DISCOUNT",
							"amount": "-126.92"
						}]
					},
					"rooms": 1,
					"childrenAges": ""
				}]
			}],
			"totalNet": "1142.58",
			"currency": "USD",
			"supplier": {
				"name": "HOTELBEDS PRODUCT,S.L.U.",
				"vatNumber": "ESB38877676"
			}
		},
		"remark": "***SDK***TESTING",
		"totalNet": 1142.58,
		"pendingAmount": 1142.58,
		"currency": "USD"
	}
}
```

Changes into:

```json
{
	"auditData": {
		"processTime": "1658",
		"timestamp": "2016-12-05 15:21:33.326",
		"requestHost": "181.164.93.206",
		"serverId": "sa3RKSJACHXE79K.env",
		"environment": "[int]",
		"release": "8629cf6ef0a2deed178b86daa0e13c79b5c99237",
		"internal": "0|2A25358C9D944521B844E4A2F354B3AA|MX||1|1|||||||||||R|1|7||||||wbxrv2d759hmvh4b4wu6jxyu||"
	},
	"booking": {
		"reference": "197-2985656",
		"clientReference": "SDK TEST",
		"creationDate": "2016-12-05",
		"status": "CONFIRMED",
		"modificationPolicies": {
			"cancellation": true,
			"modification": true
		},
		"creationUser": "wbxrv2d759hmvh4b4wu6jxyu",
		"holder": {
			"name": "ROSETTA",
			"surname": "PRUEBAS"
		},
		"hotel": {
			"checkIn": "2017-01-11",
			"checkOut": "2017-01-18",
			"code": 18968,
			"name": "Elysees Union",
			"categoryCode": "3EST",
			"categoryName": "3 STARS",
			"destinationCode": "PAR",
			"destinationName": "Paris",
			"zoneCode": 14,
			"zoneName": "Arr8/16:Etoile-C.Elysées/Trocadero",
			"latitude": "48.868387",
			"longitude": "2.291788",
			"rooms": [{
					"status": "CONFIRMED",
					"id": 1,
					"code": "QUA.ST",
					"name": "QUADRUPLE STANDARD",
					"paxes": [{
							"roomId": 1,
							"type": "AD",
							"name": "NombrePasajero1",
							"surname": "ApellidoPasajero1"
						}, {
							"roomId": 1,
							"type": "AD",
							"name": "NombrePasajero2",
							"surname": "ApellidoPasajero2"
						}, {
							"roomId": 1,
							"type": "CH",
							"age": 12,
							"name": "NombrePasajero3",
							"surname": "ApellidoPasajero3"
						}, {
							"roomId": 1,
							"type": "CH",
							"age": 13,
							"name": "NombrePasajero4",
							"surname": "ApellidoPasajero4"
						}
					],
					"rates": [{
							"rateKey": "20170111|20170118|W|197|18968|QUA.ST|FIT NET APT2|RO||1~2~2|30~30~12~13|N@0",
							"rateClass": "NOR",
							"net": "1142.58",
							"rateComments": "1x QUADRUPLE Estimated total amount of taxes & fees for this booking: 46.20 Euro   payable on arrival  ",
							"paymentType": "AT_WEB",
							"packaging": false,
							"boardCode": "RO",
							"boardName": "ROOM ONLY",
							"cancellationPolicies": [{
									"amount": "1142.58",
									"from": "2017-01-08T23:59:00+01:00"
								}, {
									"amount": "342.77",
									"from": "2016-12-27T23:59:00+01:00"
								}, {
									"amount": "91.41",
									"from": "2016-12-04T23:59:00+01:00"
								}
							],
							"rateBreakDown": {
								"rateDiscounts": [{
										"code": "SDD",
										"name": "SPECIAL DISCOUNT",
										"amount": "-126.92"
									}
								]
							},
							"rooms": 1,
							"childrenAges": ""
						}
					]
				}
			],
			"totalNet": "1142.58",
			"currency": "USD",
			"supplier": {
				"name": "HOTELBEDS PRODUCT,S.L.U.",
				"vatNumber": "ESB38877676"
			}
		},
		"remark": "***SDK***TESTING",
		"totalNet": 1142.58,
		"pendingAmount": 1142.58,
		"currency": "USD"
	}
}
```

In the first one the zonename is breaking the serialization

> "zoneName": "Arr8/16:Etoile-C.Elys�es/Trocadero",

In the second one the zonaname is not breaking anymore

> "zoneName": "Arr8/16:Etoile-C.Elysées/Trocadero",
