### PR TITLE
API version 1.2 for booking confirmation w/out CC

### DIFF
--- a/hotel-api-sdk/HotelApiClient.cs
+++ b/hotel-api-sdk/HotelApiClient.cs
@@ -269,6 +269,8 @@ namespace com.hotelbeds.distribution.hotel_api_sdk
                     client.DefaultRequestHeaders.Add("X-Signature", signature.ToString());
                     client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=utf-8");
                     client.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/json; charset=utf-8");
+                    client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "hotel-api-sdk-net");
+
 
                     // GET Method
                     if (path.getHttpMethod() == HttpMethod.Get)

--- a/hotel-api-sdk/types/HotelApiPaths.cs
+++ b/hotel-api-sdk/types/HotelApiPaths.cs
@@ -27,6 +27,10 @@ namespace com.hotelbeds.distribution.hotel_api_sdk.types
                 {
                     versionString = "1.1";
                 }
+                else if (version.version == HotelApiVersion.versions.V1_2)
+                {
+                    versionString = "1.2";
+                }
                 return urlTemplate.Replace("${path}", basePath).Replace("${version}", versionString);
             }            
 

--- a/hotel-api-sdk/types/HotelApiVersion.cs
+++ b/hotel-api-sdk/types/HotelApiVersion.cs
@@ -2,7 +2,7 @@
 {
     public class HotelApiVersion
     {
-        public enum versions { V0_2, V1, V1_1 };
+        public enum versions { V0_2, V1, V1_1, V1_2};
 
         public versions version { get; }
 


### PR DESCRIPTION
* Bumped API version to 1.2 (only used for booking confirmation without credit card details - view https://developer.hotelbeds.com/docs/read/apitude_booking/Booking_Confirmation for more details)
* Added User Agent header